### PR TITLE
Add ChatGPT question route

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_display_capture.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_display_capture.html
@@ -44,7 +44,7 @@
 
         <div class="options">
             <!-- TODO: Link to actual question page (1.1.2.1) -->
-          <a href="{{ url_for('user_question', capture_id=capture_info.capture_id) }}" class="btn-question">Poser une question</a>
+          <a href="{{ url_for('user_question_choice', capture_id=capture_info.capture_id) }}" class="btn-question">Poser une question</a>
             <!-- Link to save/modify options (1.1.2.2) -->
             <a href="{{ url_for("user_save_options", capture_id=capture_info.capture_id) }}" class="btn-save">Sauvegarder / Modifier</a>
         </div>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_question_choice.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_question_choice.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Choix du système de question</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em; }
+        .options { display: flex; gap: 1em; }
+        .options a { padding: 0.5em 1.2em; text-decoration: none; border-radius: 4px; }
+        .btn-chatgpt { background-color: #4a90e2; color: white; }
+        .btn-nlp { background-color: #28a745; color: white; }
+    </style>
+</head>
+<body>
+    <h1>Choisissez le moteur de réponse</h1>
+    <div class="options">
+        <a href="{{ url_for('user_question_chatgpt', capture_id=capture_id) }}" class="btn-chatgpt">ChatGPT</a>
+        <a href="{{ url_for('user_question_nlp', capture_id=capture_id) }}" class="btn-nlp">NLP interne</a>
+    </div>
+    <p><a href="{{ url_for('user_display_capture', filename=capture_id) }}">← Retour à l'image</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link the display page to a new question choice screen
- let users choose between ChatGPT and the NLP engine
- support ChatGPT questions with an API key
- rename the old question route to `/user/question_nlp`

## Testing
- `python -m py_compile LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e44e4fc88322929a5e5bdfa019c7