### PR TITLE
Implement config-based admin credentials

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/__init__.py
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/__init__.py
@@ -1,5 +1,6 @@
 from flask import Flask
 import os
+import json
 
 app = Flask(__name__)
 app.config['BASE_DIR'] = os.path.dirname(os.path.abspath(__file__))
@@ -27,6 +28,22 @@ for folder in data_subfolders:
     os.makedirs(path, exist_ok=True)  # Crée le dossier si inexistant
 
 app.config['VISITED_LINKS_FILE'] = os.path.join(app.config['DATA_FOLDER'], 'visited_links.json')
+
+# Load admin credentials from environment or optional config file
+admin_email = os.environ.get("ADMIN_EMAIL")
+admin_password = os.environ.get("ADMIN_PASSWORD")
+config_path = os.path.join(BASE_DIR, "admin_config.json")
+if (admin_email is None or admin_password is None) and os.path.exists(config_path):
+    try:
+        with open(config_path, "r") as f:
+            creds = json.load(f)
+        admin_email = admin_email or creds.get("ADMIN_EMAIL")
+        admin_password = admin_password or creds.get("ADMIN_PASSWORD")
+    except Exception:
+        pass
+
+app.config["ADMIN_EMAIL"] = admin_email
+app.config["ADMIN_PASSWORD"] = admin_password
 
 # Configuration Playwright
 PLAYWRIGHT_CONFIG = {

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
@@ -65,8 +65,9 @@ def login():
     if request.method == "POST":
         email = request.form.get("email")
         password = request.form.get("password")
-        # Hardcoded credentials as per spec (replace with secure method later)
-        if email == "djeryala@gmail.com" and password == "DJERI":
+        admin_email = current_app.config.get("ADMIN_EMAIL")
+        admin_password = current_app.config.get("ADMIN_PASSWORD")
+        if email == admin_email and password == admin_password:
             session["admin_logged_in"] = True
             flash("Login successful!", "success")
             return redirect(url_for("admin_dashboard"))

--- a/README.md
+++ b/README.md
@@ -43,4 +43,22 @@
 challenges: 
 1 - data collect
 
-2 - images annotation 
+2 - images annotation
+
+## Admin Credentials
+
+The admin dashboard requires credentials that can be supplied either as environment variables or through a configuration file placed at the repository root.
+
+### Using environment variables
+
+Set `ADMIN_EMAIL` and `ADMIN_PASSWORD` before starting the application:
+
+```bash
+export ADMIN_EMAIL="admin@example.com"
+export ADMIN_PASSWORD="secret"
+```
+
+### Using a config file
+
+Create an `admin_config.json` file based on the provided `admin_config.json.example` and populate it with the desired credentials.
+

--- a/admin_config.json.example
+++ b/admin_config.json.example
@@ -1,0 +1,4 @@
+{
+    "ADMIN_EMAIL": "admin@example.com",
+    "ADMIN_PASSWORD": "change_this_password"
+}


### PR DESCRIPTION
## Summary
- read admin credentials from environment variables or `admin_config.json`
- compare against those credentials in `login()`
- document credential setup in README
- add example `admin_config.json` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e45c14408322b96beee00a78a74c