### PR TITLE
Fix navigation links

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
@@ -248,6 +248,16 @@ def admin_delete_item(item_id):
     return redirect(url_for("admin_dashboard"))
 
 
+@app.route("/admin/modify_item/<item_id>")
+def admin_modify_item(item_id):
+    """Redirect admin to the manual annotation page to modify an item."""
+    if not is_admin_logged_in():
+        flash("Please log in to access this page.", "warning")
+        return redirect(url_for("login"))
+
+    return redirect(url_for("manual_annotation", capture_id=item_id))
+
+
 @app.route("/admin/fine_tune_data")
 def admin_fine_tune_data():
     # Page 1.2.1.4: Display count of items in fine_tune_data and option to launch fine-tuning
@@ -270,6 +280,17 @@ def admin_fine_tune_data():
 
     # Render the template displaying the count and the button
     return render_template("admin_fine_tune_data.html", image_count=image_count)
+
+
+@app.route("/admin/launch_finetuning", methods=["POST"])
+def admin_launch_finetuning():
+    """Placeholder route to trigger the fine-tuning process."""
+    if not is_admin_logged_in():
+        flash("Please log in to perform this action.", "warning")
+        return redirect(url_for("login"))
+
+    flash("Fine-tuning launched (simulation).", "info")
+    return redirect(url_for("admin_fine_tune_data"))
 
 
 # --- User Routes --- #

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_dashboard.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_dashboard.html
@@ -207,13 +207,13 @@
                 <a href="{{ url_for('admin_visited_links') }}">Liens Visités</a>
                 </div>
                 <div class="grid-item">
-                    <a href="#">Prédictions Validées </a>
+                    <a href="{{ url_for('admin_view_human_data', data_type='validated_predictions') }}">Prédictions Validées </a>
                 </div>
                 <div class="grid-item">
-                    <a href="#">Annotations Manuelles </a>
+                    <a href="{{ url_for('admin_view_human_data', data_type='manual_annotations') }}">Annotations Manuelles </a>
                 </div>
                 <div class="grid-item">
-                    <a href="#">Données Fine-Tuning </a>
+                    <a href="{{ url_for('admin_fine_tune_data') }}">Données Fine-Tuning </a>
                 </div>
             </div>
         </div>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_fine_tune_data.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_fine_tune_data.html
@@ -55,8 +55,7 @@
         <div class="content">
             <p class="count-info">Nombre d'images (avec JSON COCO) dans le dossier <code>fine_tune_data</code> : <strong>{{ image_count }}</strong></p>
             
-            <!-- TODO: Create route admin_launch_finetuning -->
-            <form method="post" action="#">
+            <form method="post" action="{{ url_for('admin_launch_finetuning') }}">
                 <button type="submit" class="btn-finetune" {{ "disabled" if image_count == 0 }}>
                     Lancer le Fine-Tuning
                 </button>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_view_human_data.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_view_human_data.html
@@ -33,7 +33,7 @@
                 <!-- Highlight current page? -->
                 <li><a href="{{ url_for("admin_view_human_data", data_type=\"validated_predictions\") }}">Prédictions Validées</a></li>
                 <li><a href="{{ url_for("admin_view_human_data", data_type=\"manual_annotations\") }}">Annotations Manuelles</a></li>
-                <li><a href="#">Données Fine-Tuning</a></li>
+                <li><a href="{{ url_for('admin_fine_tune_data') }}">Données Fine-Tuning</a></li>
                 <li><a href="{{ url_for("logout") }}" class="logout-link">Déconnexion</a></li>
             </ul>
         </nav>
@@ -61,8 +61,7 @@
                         <p>ID: {{ item.id }}</p>
                         <p>Image: {{ item.image_filename }}</p>
                         <p>JSON: {{ item.json_filename }}</p>
-                        {# TODO: Create route admin_view_item_detail #}
-                        <a href="#">Voir Détails / Valider</a>
+                        <a href="{{ url_for('admin_view_item_detail', item_id=item.id) }}">Voir Détails / Valider</a>
                     </div>
                 {% endfor %}
             </div>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_view_item_detail.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_view_item_detail.html
@@ -42,7 +42,7 @@
                 <li><a href="{{ url_for("admin_visited_links") }}">Liens Visités</a></li>
                 <li><a href="{{ url_for("admin_view_human_data", data_type=\"validated_predictions\") }}">Prédictions Validées</a></li>
                 <li><a href="{{ url_for("admin_view_human_data", data_type=\"manual_annotations\") }}">Annotations Manuelles</a></li>
-                <li><a href="#">Données Fine-Tuning</a></li>
+                <li><a href="{{ url_for('admin_fine_tune_data') }}">Données Fine-Tuning</a></li>
                 <li><a href="{{ url_for("logout") }}" class="logout-link">Déconnexion</a></li>
             </ul>
         </nav>
@@ -79,8 +79,7 @@
                     <form method="post" action="{{ url_for("admin_delete_item", item_id=item_id) }}" style="margin:0;" onsubmit="return confirm("Êtes-vous sûr de vouloir supprimer cet élément de human_data ?");">
                         <button type="submit" class="btn-delete">Supprimer de Human Data</button>
                     </form>
-                    <!-- TODO: Create route admin_modify_item (Roboflow iframe Page A) -->
-                    <a href="#" class="btn-modify">Modifier l'Annotation (Roboflow)</a>
+                    <a href="{{ url_for('admin_modify_item', item_id=item_id) }}" class="btn-modify">Modifier l'Annotation (Roboflow)</a>
                 </div>
             </div>
         </div>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_visited_links.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_visited_links.html
@@ -29,9 +29,9 @@
             <ul>
                 <li><a href="{{ url_for("admin_dashboard") }}">Tableau de Bord</a></li>
                 <li><a href="{{ url_for("admin_visited_links") }}">Liens Visités</a></li>
-                <li><a href="#">Prédictions Validées</a></li>
-                <li><a href="#">Annotations Manuelles</a></li>
-                <li><a href="#">Données Fine-Tuning</a></li>
+                <li><a href="{{ url_for('admin_view_human_data', data_type='validated_predictions') }}">Prédictions Validées</a></li>
+                <li><a href="{{ url_for('admin_view_human_data', data_type='manual_annotations') }}">Annotations Manuelles</a></li>
+                <li><a href="{{ url_for('admin_fine_tune_data') }}">Données Fine-Tuning</a></li>
                 <li><a href="{{ url_for("logout") }}" class="logout-link">Déconnexion</a></li>
             </ul>
         </nav>
@@ -67,7 +67,7 @@
                         <td>{{ link.timestamp | replace("T", " ") }}</td>
                         <td>{{ link.capture_id }}</td>
                         <td>{{ link.filename }}</td>
-                        <td><a href="#">Voir Capture</a></td>
+                        <td><a href="{{ url_for('user_display_capture', filename=link.filename) }}">Voir Capture</a></td>
                     </tr>
                     {% endfor %}
                 </tbody>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_display_capture.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_display_capture.html
@@ -43,7 +43,6 @@
         </div>
 
         <div class="options">
-            <!-- TODO: Link to actual question page (1.1.2.1) -->
           <a href="{{ url_for('user_question', capture_id=capture_info.capture_id) }}" class="btn-question">Poser une question</a>
             <!-- Link to save/modify options (1.1.2.2) -->
             <a href="{{ url_for("user_save_options", capture_id=capture_info.capture_id) }}" class="btn-save">Sauvegarder / Modifier</a>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_manual_annotation_options.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_manual_annotation_options.html
@@ -50,14 +50,13 @@
 
         <div class="options">
             <!-- Oui -> Page B1.1 (Remove boxes from manual annotation) -->
-            <!-- TODO: Create route user_manual_remove_boxes -->
-            <a href="#" class="btn-yes">Oui, vérifier/supprimer des boîtes</a> 
+            <a href="{{ url_for('manual_boxes_review', capture_id=capture_info.capture_id) }}" class="btn-yes">Oui, vérifier/supprimer des boîtes</a>
             <!-- Non -> Page Tou (Display final manual annotation + download) -->
             <!-- This assumes the manual annotation is saved directly to human_data -->
             <a href="{{ url_for("user_display_final_annotation", capture_id=capture_info.capture_id, source="manual_validated") }}" class="btn-no">Non, tout est correct</a> 
         </div>
 
-        <a href="{{ url_for("user_manual_annotation", capture_id=capture_info.capture_id) }}" class="back-link">Retour à l'annotation (Roboflow)</a>
+        <a href="{{ url_for("manual_annotation", capture_id=capture_info.capture_id) }}" class="back-link">Retour à l'annotation (Roboflow)</a>
         <a href="{{ url_for("index") }}" class="back-link">Retour à l'accueil</a>
     </div>
 </body>

--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_manual_annotation_prompt.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_manual_annotation_prompt.html
@@ -48,8 +48,7 @@
 
         <div class="options">
             <!-- Oui -> Page B (Roboflow iframe) -->
-            <!-- TODO: Create route user_manual_annotation -->
-            <a href="#" class="btn-yes">Oui, annoter maintenant</a> 
+            <a href="{{ url_for('manual_annotation', capture_id=capture_info.capture_id) }}" class="btn-yes">Oui, annoter maintenant</a>
             <!-- Non -> Maybe back to index or display original? Redirecting to index for now -->
             <a href="{{ url_for("index") }}" class="btn-no">Non, annuler</a> 
         </div>


### PR DESCRIPTION
## Summary
- wire up previously commented admin routes
- use `url_for` for all navigation links instead of `href="#"`
- implement placeholder admin routes for modify and fine-tune actions
- clean up obsolete TODO comments

## Testing
- `python -m py_compile LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6841e457545c8322924d61f636488c80