### PR TITLE
Fix redundant OCR image processing call

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
@@ -347,12 +347,8 @@ def user_question(capture_id):
     # === 2. Déterminer le chemin absolu réel (pour OCR)
     absolute_image_path = os.path.join(app.config["ORIGINALS_FOLDER"], image_filename)
 
-    # === 3. Traiter l'image pour l'OCR/NLP
+    # === 3. Traiter l'image pour l'OCR/NLP (une seule fois)
     nlp_system.process_image(absolute_image_path, use_layout=True)
-
-
-    # Re-traiter si jamais pas déjà fait (optionnel selon logique)
-    nlp_system.process_image(image_path, use_layout=True)
 
     answer = None
     question = None


### PR DESCRIPTION
## Summary
- remove double call to `nlp_system.process_image`
- keep single call with the absolute image path

## Testing
- `python -m py_compile LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e45926148322b019a9b1eb65abff