### PR TITLE
Remove duplicate remove_uniform_bands

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/routes.py
@@ -949,25 +949,6 @@ def save_visited_links(links):
         flash(f"Error saving visited links: {e}", "danger")
 
 
-def remove_uniform_bands(img, tolerance=5):
-    """
-    Supprime les bandes horizontales uniformes (blancs) après la suppression.
-    """
-    h, w = img.shape[:2]
-    keep_rows = []
-
-    for y in range(h):
-        row = img[y, :, :]  # ligne entière
-        max_diff = np.max(np.abs(row - row[0]))
-        if max_diff > tolerance:
-            keep_rows.append(y)
-
-    if len(keep_rows) == h:
-        return img  # rien à supprimer
-
-    # Reconstruction image nettoyée
-    new_img = img[keep_rows, :, :]
-    return new_img
 
 def save_manual_annotation_to_human_data(capture_id):
     img_extensions = [".png", ".jpg", ".jpeg"]


### PR DESCRIPTION
## Summary
- keep the image trimming helper defined at the end of `routes.py`
- delete the earlier duplicate implementation of `remove_uniform_bands`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e4559af0832285261c7ee36875f1