### PR TITLE
Fix duplicate links in capture display page

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_display_capture.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/user_display_capture.html
@@ -43,19 +43,8 @@
         </div>
 
         <div class="options">
-<div class="options">
-    <!-- Accès direct à l'ancien système de question -->
-    <a href="{{ url_for('user_question', capture_id=capture_info.capture_id) }}" class="btn-question">Poser une question</a>
-
-    <!-- Accès au nouveau choix de question -->
-    <a href="{{ url_for('user_question_choice', capture_id=capture_info.capture_id) }}" class="btn-question">Poser une question</a>
-
-    <!-- Enregistrer ou modifier l’annotation -->
-    <a href="{{ url_for('user_save_options', capture_id=capture_info.capture_id) }}" class="btn-save">Sauvegarder / Modifier</a>
-</div>
-
-            <!-- Link to save/modify options (1.1.2.2) -->
-            <a href="{{ url_for("user_save_options", capture_id=capture_info.capture_id) }}" class="btn-save">Sauvegarder / Modifier</a>
+            <a href="{{ url_for('user_question_choice', capture_id=capture_info.capture_id) }}" class="btn-question">Poser une question</a>
+            <a href="{{ url_for('user_save_options', capture_id=capture_info.capture_id) }}" class="btn-save">Sauvegarder / Modifier</a>
         </div>
 
         <a href="{{ url_for("user_capture") }}" class="back-link">Capturer une autre page</a>


### PR DESCRIPTION
## Summary
- clean up `user_display_capture.html` by removing duplicate options block
- keep one question link pointing to `user_question_choice`
- ensure save options link remains functional

## Testing
- `python - <<'PY'
from flask import Flask, render_template
import os
app = Flask(__name__)
app.secret_key='a'
app.jinja_loader.searchpath.insert(0, os.path.join('LocalApp', 'SMARTWEBSCRAPPER-CV', 'app', 'templates'))
@app.route('/user/question_choice/<capture_id>');
def user_question_choice(capture_id):
    return ''
@app.route('/user/save_options/<capture_id>');
def user_save_options(capture_id):
    return ''
@app.route('/user/capture');
def user_capture():
    return ''
@app.route('/');
def index():
    return ''
with app.test_request_context('/'):
    render_template('user_display_capture.html', capture_info={'url':'http://example.com','capture_id':'123'}, image_path='/img.png')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841edcdf9388322a3a39c66d2e5dc0c