### PR TITLE
Fix admin templates base

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/base.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/base.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Admin{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    {% block content %}{% endblock %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing `base.html` layout for admin templates

## Testing
- `python -m py_compile LocalApp/SMARTWEBSCRAPPER-CV/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6843519794388322a056d9be4e134229