### PR TITLE
Add admin manual annotations listing page

### DIFF
--- a/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_annotations_manuelles.html
+++ b/LocalApp/SMARTWEBSCRAPPER-CV/app/templates/admin_annotations_manuelles.html
@@ -1,237 +1,53 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>📝 Annotation Manuelle Admin - {{ capture_id }}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <style>
-        .annotation-container {
-            position: relative;
-            border: 2px solid #007bff;
-            border-radius: 8px;
-            overflow: hidden;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-        }
-        
-        .annotation-canvas {
-            position: absolute;
-            top: 0;
-            left: 0;
-            cursor: crosshair;
-            z-index: 10;
-        }
-        
-        .annotation-image {
-            max-width: 100%;
-            height: auto;
-            display: block;
-        }
-        
-        .annotation-box {
-            position: absolute;
-            border: 2px solid #ff6b6b;
-            background: rgba(255, 107, 107, 0.1);
-            cursor: move;
-        }
-        
-        .annotation-label {
-            position: absolute;
-            top: -25px;
-            left: 0;
-            background: #ff6b6b;
-            color: white;
-            padding: 2px 8px;
-            border-radius: 4px;
-            font-size: 12px;
-            white-space: nowrap;
-        }
-        
-        .class-buttons {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 5px;
-            margin: 15px 0;
-        }
-        
-        .class-btn {
-            padding: 5px 12px;
-            border: 1px solid #ddd;
-            background: white;
-            border-radius: 20px;
-            cursor: pointer;
-            font-size: 12px;
-        }
-        
-        .class-btn.active {
-            background: #007bff;
-            color: white;
-        }
-        
-        .annotations-list {
-            max-height: 300px;
-            overflow-y: auto;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            padding: 10px;
-        }
-        
-        .annotation-item {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 5px;
-            border-bottom: 1px solid #eee;
-        }
-        
-        .delete-annotation {
-            color: #dc3545;
-            cursor: pointer;
-            font-weight: bold;
-        }
-        
-        .admin-badge {
-            background: linear-gradient(45deg, #ff6b6b, #ffd93d);
-            color: white;
-            padding: 5px 15px;
-            border-radius: 20px;
-            font-weight: bold;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        }
-        
-        .save-btn {
-            background: linear-gradient(45deg, #28a745, #20c997);
-            border: none;
-            color: white;
-            padding: 12px 30px;
-            border-radius: 25px;
-            font-weight: bold;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-            transition: all 0.3s ease;
-        }
-        
-        .save-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 6px 12px rgba(0,0,0,0.3);
-        }
-    </style>
-</head>
-<body>
-    <div class="container-fluid py-4">
-        <!-- Header Admin -->
-        <div class="row mb-4">
-            <div class="col">
-                <div class="d-flex justify-content-between align-items-center">
-                    <h2>📝 Annotation Manuelle Administrateur</h2>
-                    <span class="admin-badge">🔧 Mode Admin</span>
-                </div>
-                <p class="text-muted">
-                    <strong>Image:</strong> {{ capture_id }} | 
-                    <strong>⚠️ Important:</strong> Ces annotations vont directement dans <code>fine_tune_data/</code>
-                </p>
-            </div>
-        </div>
+{% extends "base.html" %}
 
-        <!-- Navigation -->
-        <div class="row mb-3">
-            <div class="col">
-                <nav aria-label="breadcrumb">
-                    <ol class="breadcrumb">
-                        <li class="breadcrumb-item"><a href="{{ url_for('admin_dashboard') }}">Dashboard</a></li>
-                        <li class="breadcrumb-item active">Annotation Manuelle</li>
-                        <li class="breadcrumb-item active">{{ capture_id }}</li>
-                    </ol>
-                </nav>
-            </div>
-        </div>
+{% block title %}Annotations Manuelles{% endblock %}
 
-        <div class="row">
-            <!-- Image et Canvas d'annotation -->
-            <div class="col-lg-8">
-                <div class="card">
-                    <div class="card-header">
-                        <h5>🎯 Interface d'Annotation</h5>
-                    </div>
-                    <div class="card-body">
-                        <!-- Sélection de classe -->
-                        <div class="mb-3">
-                            <label class="form-label fw-bold">Classe sélectionnée :</label>
-                            <div class="class-buttons">
-                                <div class="class-btn active" data-class="advertisement">📢 Advertisement</div>
-                                <div class="class-btn" data-class="header">🔝 Header</div>
-                                <div class="class-btn" data-class="footer">🔻 Footer</div>
-                                <div class="class-btn" data-class="left sidebar">◀️ Left Sidebar</div>
-                                <div class="class-btn" data-class="right sidebar">▶️ Right Sidebar</div>
-                                <div class="class-btn" data-class="logo">🏷️ Logo</div>
-                                <div class="class-btn" data-class="title">📋 Title</div>
-                                <div class="class-btn" data-class="description">📝 Description</div>
-                                <div class="class-btn" data-class="media">🎥 Media</div>
-                                <div class="class-btn" data-class="commentaire">💬 Commentaire</div>
-                                <div class="class-btn" data-class="likes">❤️ Likes</div>
-                                <div class="class-btn" data-class="vues">👁️ Vues</div>
-                                <div class="class-btn" data-class="recommendations">🎯 Recommendations</div>
-                                <div class="class-btn" data-class="suggestions">💡 Suggestions</div>
-                                <div class="class-btn" data-class="pop up">⚡ Pop Up</div>
-                                <div class="class-btn" data-class="chaine">📺 Chaine</div>
-                                <div class="class-btn" data-class="other">❓ Other</div>
+{% block content %}
+<div class="container-fluid py-4">
+    <!-- Header -->
+    <div class="row mb-4">
+        <div class="col">
+            <div class="d-flex justify-content-between align-items-center">
+                <h2>✍️ Annotations Manuelles</h2>
+                <span class="badge bg-primary fs-6">{{ items|length }} éléments</span>
+            </div>
+            <p class="text-muted">
+                Images annotées manuellement par les utilisateurs
+            </p>
+        </div>
+    </div>
+
+    <!-- Navigation -->
+    <div class="row mb-3">
+        <div class="col">
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="{{ url_for('admin_dashboard') }}">Dashboard</a></li>
+                    <li class="breadcrumb-item active">Annotations Manuelles</li>
+                </ol>
+            </nav>
+        </div>
+    </div>
+
+    <!-- Actions groupées -->
+    <div class="row mb-3">
+        <div class="col">
+            <div class="card">
+                <div class="card-body">
+                    <div class="row align-items-center">
+                        <div class="col-md-8">
+                            <h6 class="mb-0">⚡ Actions groupées</h6>
+                            <small class="text-muted">Sélectionnez des éléments puis choisissez une action</small>
+                        </div>
+                        <div class="col-md-4 text-end">
+                            <div class="btn-group">
+                                <button type="button" class="btn btn-success btn-sm" onclick="validateSelected()">
+                                    ✅ Valider sélection
+                                </button>
+                                <button type="button" class="btn btn-danger btn-sm" onclick="deleteSelected()">
+                                    🗑️ Supprimer sélection
+                                </button>
                             </div>
-                        </div>
-
-                        <!-- Container pour l'image et le canvas -->
-                        <div class="annotation-container" id="annotationContainer">
-                            <img src="{{ image_url }}" alt="Image à annoter" class="annotation-image" id="annotationImage">
-                            <canvas id="annotationCanvas" class="annotation-canvas"></canvas>
-                        </div>
-
-                        <!-- Instructions -->
-                        <div class="alert alert-info mt-3">
-                            <strong>📋 Instructions :</strong>
-                            <ul class="mb-0">
-                                <li>Sélectionnez une classe ci-dessus</li>
-                                <li>Cliquez et glissez sur l'image pour créer une boîte</li>
-                                <li>Vous pouvez déplacer les boîtes créées</li>
-                                <li>Cliquez sur ❌ dans la liste pour supprimer une annotation</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Liste des annotations et actions -->
-            <div class="col-lg-4">
-                <div class="card">
-                    <div class="card-header">
-                        <h5>📝 Annotations Créées</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="annotations-list" id="annotationsList">
-                            <p class="text-muted text-center">Aucune annotation pour le moment</p>
-                        </div>
-
-                        <!-- Actions -->
-                        <div class="mt-4">
-                            <button type="button" class="btn save-btn w-100 mb-2" onclick="saveAnnotations()">
-                                💾 Sauvegarder dans Fine-Tune Data
-                            </button>
-                            <button type="button" class="btn btn-outline-secondary w-100 mb-2" onclick="clearAllAnnotations()">
-                                🗑️ Effacer Tout
-                            </button>
-                            <a href="{{ url_for('admin_dashboard') }}" class="btn btn-outline-primary w-100">
-                                ↩️ Retour au Dashboard
-                            </a>
-                        </div>
-
-                        <!-- Statistiques -->
-                        <div class="mt-3 p-3 bg-light rounded">
-                            <small class="text-muted">
-                                <strong>📊 Stats :</strong><br>
-                                Annotations créées : <span id="annotationCount">0</span><br>
-                                Classe active : <span id="activeClass">advertisement</span>
-                            </small>
                         </div>
                     </div>
                 </div>
@@ -239,314 +55,252 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script>
-        class AdminAnnotationTool {
-            constructor() {
-                this.canvas = document.getElementById('annotationCanvas');
-                this.ctx = this.canvas.getContext('2d');
-                this.image = document.getElementById('annotationImage');
-                this.container = document.getElementById('annotationContainer');
-                
-                this.annotations = [];
-                this.currentClass = 'advertisement';
-                this.isDrawing = false;
-                this.isDragging = false;
-                this.startX = 0;
-                this.startY = 0;
-                this.currentAnnotation = null;
-                this.draggedAnnotation = null;
-                this.dragOffset = { x: 0, y: 0 };
-                this.annotationIdCounter = 1;
-                
-                this.setupCanvas();
-                this.setupEventListeners();
-            }
-            
-            setupCanvas() {
-                // Attendre que l'image soit chargée
-                this.image.onload = () => {
-                    this.resizeCanvas();
-                };
-                
-                // Si l'image est déjà chargée
-                if (this.image.complete) {
-                    this.resizeCanvas();
-                }
-            }
-            
-            resizeCanvas() {
-                const rect = this.image.getBoundingClientRect();
-                this.canvas.width = this.image.offsetWidth;
-                this.canvas.height = this.image.offsetHeight;
-                this.redrawAnnotations();
-            }
-            
-            setupEventListeners() {
-                // Sélection de classe
-                document.querySelectorAll('.class-btn').forEach(btn => {
-                    btn.addEventListener('click', (e) => {
-                        document.querySelectorAll('.class-btn').forEach(b => b.classList.remove('active'));
-                        e.target.classList.add('active');
-                        this.currentClass = e.target.dataset.class;
-                        document.getElementById('activeClass').textContent = this.currentClass;
-                    });
-                });
-                
-                // Events canvas
-                this.canvas.addEventListener('mousedown', this.onMouseDown.bind(this));
-                this.canvas.addEventListener('mousemove', this.onMouseMove.bind(this));
-                this.canvas.addEventListener('mouseup', this.onMouseUp.bind(this));
-                
-                // Resize
-                window.addEventListener('resize', () => {
-                    setTimeout(() => this.resizeCanvas(), 100);
-                });
-            }
-            
-            getMousePos(e) {
-                const rect = this.canvas.getBoundingClientRect();
-                return {
-                    x: e.clientX - rect.left,
-                    y: e.clientY - rect.top
-                };
-            }
-            
-            onMouseDown(e) {
-                const pos = this.getMousePos(e);
-                
-                // Vérifier si on clique sur une annotation existante pour la déplacer
-                const clickedAnnotation = this.getAnnotationAtPosition(pos.x, pos.y);
-                
-                if (clickedAnnotation) {
-                    this.isDragging = true;
-                    this.draggedAnnotation = clickedAnnotation;
-                    this.dragOffset = {
-                        x: pos.x - clickedAnnotation.x,
-                        y: pos.y - clickedAnnotation.y
-                    };
-                } else {
-                    // Créer une nouvelle annotation
-                    this.isDrawing = true;
-                    this.startX = pos.x;
-                    this.startY = pos.y;
-                    
-                    this.currentAnnotation = {
-                        id: this.annotationIdCounter++,
-                        x: pos.x,
-                        y: pos.y,
-                        width: 0,
-                        height: 0,
-                        class: this.currentClass
-                    };
-                }
-            }
-            
-            onMouseMove(e) {
-                const pos = this.getMousePos(e);
-                
-                if (this.isDragging && this.draggedAnnotation) {
-                    // Déplacer l'annotation
-                    this.draggedAnnotation.x = pos.x - this.dragOffset.x;
-                    this.draggedAnnotation.y = pos.y - this.dragOffset.y;
-                    this.redrawAnnotations();
-                } else if (this.isDrawing && this.currentAnnotation) {
-                    // Dessiner la nouvelle annotation
-                    this.currentAnnotation.width = pos.x - this.startX;
-                    this.currentAnnotation.height = pos.y - this.startY;
-                    this.redrawAnnotations();
-                    this.drawCurrentAnnotation();
-                }
-            }
-            
-            onMouseUp(e) {
-                if (this.isDrawing && this.currentAnnotation) {
-                    // Valider l'annotation si elle a une taille minimale
-                    if (Math.abs(this.currentAnnotation.width) > 10 && Math.abs(this.currentAnnotation.height) > 10) {
-                        // Normaliser les coordonnées (si width/height négatifs)
-                        if (this.currentAnnotation.width < 0) {
-                            this.currentAnnotation.x += this.currentAnnotation.width;
-                            this.currentAnnotation.width = Math.abs(this.currentAnnotation.width);
-                        }
-                        if (this.currentAnnotation.height < 0) {
-                            this.currentAnnotation.y += this.currentAnnotation.height;
-                            this.currentAnnotation.height = Math.abs(this.currentAnnotation.height);
-                        }
-                        
-                        this.annotations.push(this.currentAnnotation);
-                        this.updateAnnotationsList();
-                    }
-                }
-                
-                this.isDrawing = false;
-                this.isDragging = false;
-                this.currentAnnotation = null;
-                this.draggedAnnotation = null;
-                this.redrawAnnotations();
-            }
-            
-            getAnnotationAtPosition(x, y) {
-                for (let i = this.annotations.length - 1; i >= 0; i--) {
-                    const ann = this.annotations[i];
-                    if (x >= ann.x && x <= ann.x + ann.width && 
-                        y >= ann.y && y <= ann.y + ann.height) {
-                        return ann;
-                    }
-                }
-                return null;
-            }
-            
-            drawCurrentAnnotation() {
-                if (!this.currentAnnotation) return;
-                
-                this.ctx.strokeStyle = '#ff6b6b';
-                this.ctx.lineWidth = 2;
-                this.ctx.setLineDash([5, 5]);
-                this.ctx.strokeRect(
-                    this.currentAnnotation.x,
-                    this.currentAnnotation.y,
-                    this.currentAnnotation.width,
-                    this.currentAnnotation.height
-                );
-                this.ctx.setLineDash([]);
-            }
-            
-            redrawAnnotations() {
-                this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-                
-                this.annotations.forEach(ann => {
-                    // Dessiner la boîte
-                    this.ctx.strokeStyle = this.getClassColor(ann.class);
-                    this.ctx.lineWidth = 2;
-                    this.ctx.strokeRect(ann.x, ann.y, ann.width, ann.height);
-                    
-                    // Dessiner le label
-                    this.ctx.fillStyle = this.getClassColor(ann.class);
-                    this.ctx.fillRect(ann.x, ann.y - 20, ann.class.length * 8 + 10, 18);
-                    this.ctx.fillStyle = 'white';
-                    this.ctx.font = '12px Arial';
-                    this.ctx.fillText(ann.class, ann.x + 5, ann.y - 6);
-                });
-            }
-            
-            getClassColor(className) {
-                const colors = {
-                    'advertisement': '#ff6b6b',
-                    'header': '#4ecdc4',
-                    'footer': '#45b7d1',
-                    'left sidebar': '#96ceb4',
-                    'right sidebar': '#ffeaa7',
-                    'logo': '#dda0dd',
-                    'title': '#ff7675',
-                    'description': '#74b9ff',
-                    'media': '#00b894',
-                    'commentaire': '#fdcb6e',
-                    'likes': '#e17055',
-                    'vues': '#a29bfe',
-                    'recommendations': '#fd79a8',
-                    'suggestions': '#e84393',
-                    'pop up': '#ff9ff3',
-                    'chaine': '#54a0ff',
-                    'other': '#636e72'
-                };
-                return colors[className] || '#636e72';
-            }
-            
-            updateAnnotationsList() {
-                const list = document.getElementById('annotationsList');
-                
-                if (this.annotations.length === 0) {
-                    list.innerHTML = '<p class="text-muted text-center">Aucune annotation pour le moment</p>';
-                } else {
-                    list.innerHTML = this.annotations.map(ann => `
-                        <div class="annotation-item">
-                            <span style="color: ${this.getClassColor(ann.class)}">
-                                <strong>${ann.class}</strong> (${Math.round(ann.width)}×${Math.round(ann.height)})
-                            </span>
-                            <span class="delete-annotation" onclick="annotationTool.deleteAnnotation(${ann.id})">❌</span>
+    <!-- Liste des annotations -->
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <h5>📋 Liste des Annotations</h5>
+                </div>
+                <div class="card-body">
+                    {% if items %}
+                        <div class="table-responsive">
+                            <table class="table table-hover">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th width="40">
+                                            <input type="checkbox" id="selectAll" onchange="toggleSelectAll()">
+                                        </th>
+                                        <th>🆔 ID</th>
+                                        <th>🖼️ Image</th>
+                                        <th>📝 Fichier JSON</th>
+                                        <th>🕒 Date</th>
+                                        <th>⚡ Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for item in items %}
+                                    <tr>
+                                        <td>
+                                            <input type="checkbox" class="item-checkbox" value="{{ item.id }}">
+                                        </td>
+                                        <td>
+                                            <strong>{{ item.id }}</strong><br>
+                                            <small class="text-muted">Annotation manuelle</small>
+                                        </td>
+                                        <td>
+                                            <div class="d-flex align-items-center">
+                                                <div class="me-3">
+                                                    <div class="bg-primary text-white rounded d-flex align-items-center justify-content-center" 
+                                                         style="width: 40px; height: 40px;">
+                                                        🖼️
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <strong>{{ item.image_filename }}</strong><br>
+                                                    <small class="text-muted">Image annotée</small>
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td>
+                                            <span class="badge bg-success">📝 {{ item.json_filename }}</span>
+                                        </td>
+                                        <td>
+                                            {{ item.timestamp | timestamp_to_date }}<br>
+                                            <small class="text-muted">{{ item.timestamp | timestamp_to_date }}</small>
+                                        </td>
+                                        <td>
+                                            <div class="btn-group btn-group-sm" role="group">
+                                                <!-- Voir détails -->
+                                                <a href="{{ url_for('admin_annotation_manuelle_detail', item_id=item.id) }}"
+                                                   class="btn btn-outline-info" title="Voir les détails">
+                                                    🔍 Détails
+                                                </a>
+                                                
+                                                <!-- Actions rapides -->
+                                                <div class="btn-group btn-group-sm" role="group">
+                                                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" 
+                                                            data-bs-toggle="dropdown">
+                                                        ⚡ Actions
+                                                    </button>
+                                                    <ul class="dropdown-menu">
+                                                        <li>
+                                                            <form method="POST" action="{{ url_for('admin_action_annotation_manuelle', item_id=item.id, action='validate') }}" class="d-inline">
+                                                                <button type="submit" class="dropdown-item text-success" 
+                                                                        onclick="return confirm('✅ Valider {{ item.id }} ?\n\nCette action va déplacer les fichiers vers fine_tune_data/ et supprimer les autres copies.')">
+                                                                    ✅ Valider
+                                                                </button>
+                                                            </form>
+                                                        </li>
+                                                        <li>
+                                                            <a class="dropdown-item text-warning" 
+                                                               href="{{ url_for('admin_annotation_manuelle', capture_id=item.id) }}">
+                                                                ✏️ Modifier
+                                                            </a>
+                                                        </li>
+                                                        <li><hr class="dropdown-divider"></li>
+                                                        <li>
+                                                            <form method="POST" action="{{ url_for('admin_action_annotation_manuelle', item_id=item.id, action='delete') }}" class="d-inline">
+                                                                <button type="submit" class="dropdown-item text-danger" 
+                                                                        onclick="return confirm('🗑️ SUPPRIMER {{ item.id }} ?\n\n⚠️ Cette action supprimera TOUS les fichiers liés à cette annotation.\n\nCette action est IRRÉVERSIBLE !')">
+                                                                    🗑️ Supprimer
+                                                                </button>
+                                                            </form>
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
                         </div>
-                    `).join('');
-                }
-                
-                document.getElementById('annotationCount').textContent = this.annotations.length;
-            }
+                    {% else %}
+                        <div class="text-center text-muted py-5">
+                            <div class="display-1">📭</div>
+                            <h4>Aucune annotation manuelle</h4>
+                            <p>Les annotations créées manuellement par les utilisateurs apparaîtront ici.</p>
+                            <hr>
+                            <small>
+                                Les utilisateurs doivent d'abord capturer des pages puis dessiner leurs annotations.
+                            </small>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Aide et informations -->
+    <div class="row mt-4">
+        <div class="col-12">
+            <div class="card border-info">
+                <div class="card-header bg-info text-white">
+                    <h6 class="mb-0">💡 À propos des Annotations Manuelles</h6>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h6>🔄 Workflow :</h6>
+                            <ol>
+                                <li><strong>Capture :</strong> L'utilisateur capture une page web</li>
+                                <li><strong>Annotation manuelle :</strong> L'utilisateur dessine les boîtes</li>
+                                <li><strong>Stockage :</strong> Les données arrivent dans <code>human_data/manual/</code></li>
+                                <li><strong>Validation admin :</strong> Vous décidez de valider, modifier ou supprimer</li>
+                            </ol>
+                        </div>
+                        <div class="col-md-6">
+                            <h6>⚡ Actions disponibles :</h6>
+                            <ul>
+                                <li><strong>✅ Valider :</strong> Déplace vers <code>fine_tune_data/</code> pour réentraînement</li>
+                                <li><strong>✏️ Modifier :</strong> Ouvre l'interface d'annotation admin (Page AA)</li>
+                                <li><strong>🗑️ Supprimer :</strong> Supprime complètement tous les fichiers liés</li>
+                            </ul>
+                            
+                            <div class="alert alert-warning mt-3">
+                                <small>
+                                    <strong>⚠️ Important :</strong> Après validation, les fichiers vont dans <code>fine_tune_data/</code>
+                                    et sont supprimés d'ici. Le lien d'origine reste dans <code>visited_links.json</code>.
+                                </small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+function toggleSelectAll() {
+    const selectAll = document.getElementById('selectAll');
+    const checkboxes = document.querySelectorAll('.item-checkbox');
+    
+    checkboxes.forEach(checkbox => {
+        checkbox.checked = selectAll.checked;
+    });
+}
+
+function getSelectedItems() {
+    const checkboxes = document.querySelectorAll('.item-checkbox:checked');
+    return Array.from(checkboxes).map(cb => cb.value);
+}
+
+function validateSelected() {
+    const selected = getSelectedItems();
+    if (selected.length === 0) {
+        alert('⚠️ Veuillez sélectionner au moins un élément.');
+        return;
+    }
+    
+    if (confirm(`✅ Valider ${selected.length} annotation(s) ?\n\nCes éléments seront déplacés vers fine_tune_data/ et supprimés d'ici.\n\nContinuer ?`)) {
+        // TODO: Implémenter la validation groupée
+        alert('🚧 Fonctionnalité en cours de développement');
+    }
+}
+
+function deleteSelected() {
+    const selected = getSelectedItems();
+    if (selected.length === 0) {
+        alert('⚠️ Veuillez sélectionner au moins un élément.');
+        return;
+    }
+    
+    if (confirm(`🗑️ SUPPRIMER ${selected.length} annotation(s) ?\n\n⚠️ Cette action supprimera TOUS les fichiers liés à ces annotations.\n\n❌ CETTE ACTION EST IRRÉVERSIBLE !\n\nContinuer ?`)) {
+        // TODO: Implémenter la suppression groupée
+        alert('🚧 Fonctionnalité en cours de développement');
+    }
+}
+
+// Mettre à jour la case "tout sélectionner" quand on change les cases individuelles
+document.addEventListener('DOMContentLoaded', function() {
+    const checkboxes = document.querySelectorAll('.item-checkbox');
+    const selectAll = document.getElementById('selectAll');
+    
+    checkboxes.forEach(checkbox => {
+        checkbox.addEventListener('change', function() {
+            const checkedCount = document.querySelectorAll('.item-checkbox:checked').length;
+            const totalCount = checkboxes.length;
             
-            deleteAnnotation(id) {
-                this.annotations = this.annotations.filter(ann => ann.id !== id);
-                this.updateAnnotationsList();
-                this.redrawAnnotations();
-            }
-            
-            clearAll() {
-                this.annotations = [];
-                this.updateAnnotationsList();
-                this.redrawAnnotations();
-            }
-            
-            getAnnotationsForSave() {
-                return this.annotations.map(ann => ({
-                    id: ann.id,
-                    value: {
-                        x: (ann.x / this.canvas.width) * 100,
-                        y: (ann.y / this.canvas.height) * 100,
-                        width: (ann.width / this.canvas.width) * 100,
-                        height: (ann.height / this.canvas.height) * 100,
-                        rectanglelabels: [ann.class]
-                    }
-                }));
-            }
-        }
-        
-        // Initialiser l'outil d'annotation
-        let annotationTool;
-        document.addEventListener('DOMContentLoaded', () => {
-            annotationTool = new AdminAnnotationTool();
+            selectAll.checked = checkedCount === totalCount;
+            selectAll.indeterminate = checkedCount > 0 && checkedCount < totalCount;
         });
-        
-        // Fonctions globales
-        function saveAnnotations() {
-            const annotations = annotationTool.getAnnotationsForSave();
-            
-            if (annotations.length === 0) {
-                alert('⚠️ Aucune annotation à sauvegarder !');
-                return;
-            }
-            
-            const confirmMsg = `🚀 Sauvegarder ${annotations.length} annotation(s) dans fine_tune_data ?\n\n⚠️ ATTENTION: Cette action va:\n- Sauvegarder directement dans fine_tune_data/\n- Supprimer l'image des dossiers human_data/\n\nContinuer ?`;
-            
-            if (!confirm(confirmMsg)) return;
-            
-            fetch('/admin/save_annotation_manuelle', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    capture_id: '{{ capture_id }}',
-                    annotations: annotations
-                })
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.status === 'success') {
-                    alert('✅ ' + data.message);
-                    if (data.redirect) {
-                        window.location.href = data.redirect;
-                    }
-                } else {
-                    alert('❌ Erreur: ' + data.error);
-                }
-            })
-            .catch(error => {
-                alert('❌ Erreur de connexion: ' + error);
-            });
-        }
-        
-        function clearAllAnnotations() {
-            if (confirm('🗑️ Supprimer toutes les annotations ?')) {
-                annotationTool.clearAll();
-            }
-        }
-    </script>
-</body>
-</html>
+    });
+});
+</script>
+
+<style>
+.card {
+    border-radius: 12px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.table th {
+    border-top: none;
+    font-weight: 600;
+}
+
+.btn-group-sm .btn {
+    border-radius: 6px;
+}
+
+.dropdown-menu {
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.badge {
+    border-radius: 8px;
+}
+
+.alert {
+    border-radius: 8px;
+}
+
+.table-hover tbody tr:hover {
+    background-color: rgba(0, 123, 255, 0.05);
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace old `admin_annotations_manuelles.html` with a page that lists user manual annotations
- update links and actions to use existing admin endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684386d2e0ec8322b0b59a6dc7c69699